### PR TITLE
Some small suggestions

### DIFF
--- a/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
+++ b/compiler/plugins/target/AMD-AIE/iree-amd-aie/IR/AMDAIEOps.td
@@ -273,7 +273,7 @@ def AMDAIE_NpuDmaCpyNdOp: AMDAIE_Op<"npu.dma_cpy_nd",
     // return 0. Else cast the memory space attribute to an integer. 
     uint64_t getSourceMemorySpaceAsUInt() {
       Attribute memSpace = getSourceMemorySpace();
-      return memSpace ? dyn_cast<IntegerAttr>(memSpace).getInt() : 0;
+      return memSpace ? cast<IntegerAttr>(memSpace).getInt() : 0;
     }
 
     // Return the target memref type. This is retrieved using information from
@@ -293,7 +293,7 @@ def AMDAIE_NpuDmaCpyNdOp: AMDAIE_Op<"npu.dma_cpy_nd",
     // return 0. Else cast the memory space attribute to an integer. 
     uint64_t getTargetMemorySpaceAsUInt() {
       Attribute memSpace = getTargetMemorySpace();
-      return memSpace ? dyn_cast<IntegerAttr>(memSpace).getInt() : 0;
+      return memSpace ? cast<IntegerAttr>(memSpace).getInt() : 0;
     }
 
     // A utility to create a new doubly strided operation from this one with a
@@ -537,7 +537,7 @@ def AMDAIE_LogicalObjectFifoFromMemrefOp
     // Else cast the memory space attribute to an integer. 
     uint64_t getMemorySpaceAsUInt() {
       Attribute memSpace = getMemorySpace();
-      return memSpace ? dyn_cast<IntegerAttr>(memSpace).getInt() : 0;
+      return memSpace ? cast<IntegerAttr>(memSpace).getInt() : 0;
     }
 
     // Return the source memref type.


### PR DESCRIPTION
... thought I'd be easier to do as a PR. 

- use concept of 'ancestor' which exists upstream (recursive parents)
- use cast if you're not going to check for nullptr after dyn_cast
- emit error from the scene of the crime (better diagnostics, in theory). 

Also, I'm wondering if a pattern approach is best here, rather than a simple pass which walks the IR once. We've had discussions about this previously in the team and the general consensus was that simple IR walks should be used unless you really need the fixed point convergence of patterns. I find it easier (not impossible) to emit errors and signal pass failures when not using patterns. 